### PR TITLE
Change tap docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🍺 `monzo/tap`
 
-This Homebrew [Tap](http://docs.brew.sh/brew-tap.html) contains formulae for **publicly visible** Monzo tools.
+This Homebrew [Tap](https://docs.brew.sh/Taps) contains formulae for **publicly visible** Monzo tools.
 
 If you make a tool to use locally, please make a formula for it so others can install it easily. 😇
 


### PR DESCRIPTION
Tap URL was pointing to a non-existent doc page, checked archive.org to make sure that the replacement URL was the same page as intended

🍺 